### PR TITLE
Pod changes: Updated Pods and enabled some Obj-C/Swift interoperability

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,15 +4,18 @@ platform :ios, '8.0'
 
 inhibit_all_warnings!
 
-pod 'MTDates'
-pod 'AFNetworking'
-pod 'MTCardLayout'
-pod 'MBProgressHUD'
-pod 'IHKeyboardAvoiding'
+target 'SelfConference' do
+    pod 'MTDates'
+    pod 'AFNetworking'
+    pod 'MTCardLayout'
+    pod 'MBProgressHUD'
+    pod 'IHKeyboardAvoiding'
 
-# Since they haven't shipped a release lately. This build is stable though.
-pod 'MagicalRecord', :git => "https://github.com/magicalpanda/MagicalRecord.git", :tag => "v2.3.0-beta.5"
+    # Since they haven't shipped a release lately. This build is stable though.
+    pod 'MagicalRecord', :git => "https://github.com/magicalpanda/MagicalRecord.git", :tag => "v2.3.0-beta.5"
+end
 
-target :SelfConferenceTests, :exclusive => true do
+target 'SelfConferenceTests' do
     pod 'Kiwi'
+
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,33 +1,27 @@
 PODS:
-  - AFNetworking (2.5.4):
-    - AFNetworking/NSURLConnection (= 2.5.4)
-    - AFNetworking/NSURLSession (= 2.5.4)
-    - AFNetworking/Reachability (= 2.5.4)
-    - AFNetworking/Security (= 2.5.4)
-    - AFNetworking/Serialization (= 2.5.4)
-    - AFNetworking/UIKit (= 2.5.4)
-  - AFNetworking/NSURLConnection (2.5.4):
+  - AFNetworking (3.2.1):
+    - AFNetworking/NSURLSession (= 3.2.1)
+    - AFNetworking/Reachability (= 3.2.1)
+    - AFNetworking/Security (= 3.2.1)
+    - AFNetworking/Serialization (= 3.2.1)
+    - AFNetworking/UIKit (= 3.2.1)
+  - AFNetworking/NSURLSession (3.2.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.4):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.4)
-  - AFNetworking/Security (2.5.4)
-  - AFNetworking/Serialization (2.5.4)
-  - AFNetworking/UIKit (2.5.4):
-    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (3.2.1)
+  - AFNetworking/Security (3.2.1)
+  - AFNetworking/Serialization (3.2.1)
+  - AFNetworking/UIKit (3.2.1):
     - AFNetworking/NSURLSession
-  - IHKeyboardAvoiding (2.2)
-  - Kiwi (2.3.1)
+  - IHKeyboardAvoiding (4.6)
+  - Kiwi (3.0.0)
   - MagicalRecord (2.3.0-beta.5):
     - MagicalRecord/Core (= 2.3.0-beta.5)
   - MagicalRecord/Core (2.3.0-beta.5)
-  - MBProgressHUD (0.9.1)
+  - MBProgressHUD (1.1.0)
   - MTCardLayout (1.0.3)
-  - MTDates (1.0.2)
+  - MTDates (1.0.3)
 
 DEPENDENCIES:
   - AFNetworking
@@ -58,13 +52,13 @@ CHECKOUT OPTIONS:
     :tag: v2.3.0-beta.5
 
 SPEC CHECKSUMS:
-  AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
-  IHKeyboardAvoiding: c48e2aa88064f502ff3ba135d4b1998c175c6dfe
-  Kiwi: f038a6c61f7a9e4d7766bff5717aa3b3fdb75f55
+  AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
+  IHKeyboardAvoiding: 2a664fdb5f964359fa7ec8fc5c9aebb447583ff8
+  Kiwi: fbeafef0f00e4d8f7dcb3420a4930afe70af77f7
   MagicalRecord: 6c9674adfa596ba5828fbecb21c938f041f64a67
-  MBProgressHUD: c47f2c166c126cf2ce36498d80f33e754d4e93ad
+  MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
   MTCardLayout: 3baf5ac3bd21e6149b561dd7bca708f1ceccf962
-  MTDates: aa8006ac046c3fc4f2bb9df95603e9b5bdac9467
+  MTDates: c65affdfb7b34001c5c9e3fe0beac4b1b8334a58
 
 PODFILE CHECKSUM: d4a34c3b8a165ff3bdfbb626613185bef010b007
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -38,6 +38,15 @@ DEPENDENCIES:
   - MTCardLayout
   - MTDates
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - AFNetworking
+    - IHKeyboardAvoiding
+    - Kiwi
+    - MBProgressHUD
+    - MTCardLayout
+    - MTDates
+
 EXTERNAL SOURCES:
   MagicalRecord:
     :git: https://github.com/magicalpanda/MagicalRecord.git
@@ -57,4 +66,6 @@ SPEC CHECKSUMS:
   MTCardLayout: 3baf5ac3bd21e6149b561dd7bca708f1ceccf962
   MTDates: aa8006ac046c3fc4f2bb9df95603e9b5bdac9467
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: d4a34c3b8a165ff3bdfbb626613185bef010b007
+
+COCOAPODS: 1.6.1

--- a/SelfConference.xcodeproj/project.pbxproj
+++ b/SelfConference.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1099BA1573579EE9343BCCA9 /* libPods-SelfConference.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BA4EAE78649D1E700745240 /* libPods-SelfConference.a */; };
 		1F0734EB1B0C1B7B00A74989 /* SCSpeakerCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0734EA1B0C1B7B00A74989 /* SCSpeakerCollectionViewCell.m */; };
 		1F0734EE1B0C203900A74989 /* UIAlertController+SCAlertController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0734ED1B0C203900A74989 /* UIAlertController+SCAlertController.m */; };
 		1F0734F11B0C215B00A74989 /* UIAlertAction+SCAlertAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0734F01B0C215B00A74989 /* UIAlertAction+SCAlertAction.m */; };
@@ -59,8 +60,7 @@
 		1FD256731B0D58540089122A /* UIView+MBProgressHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FD256721B0D58540089122A /* UIView+MBProgressHUD.m */; };
 		1FE566741B0D7A6B00044DFE /* SCNameLabelHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FE566731B0D7A6B00044DFE /* SCNameLabelHeaderView.m */; };
 		1FE566771B0D812000044DFE /* SCCodeOfConductViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FE566761B0D812000044DFE /* SCCodeOfConductViewController.m */; };
-		52177A65E8B8CFE8659C76EF /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B1457BA96527132726AC017 /* libPods.a */; };
-		FEEAC01EB9E2FC1CB6FE80F7 /* libPods-SelfConferenceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8F553853A58875DD1A6969 /* libPods-SelfConferenceTests.a */; };
+		7DBD12AE835AEF03A63F5646 /* libPods-SelfConferenceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D3D44B76A75D0987CA105EFC /* libPods-SelfConferenceTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +75,7 @@
 
 /* Begin PBXFileReference section */
 		00C93AD11C4EE64D00C4B6B3 /* SelfConferenceDataModel 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "SelfConferenceDataModel 3.xcdatamodel"; sourceTree = "<group>"; };
+		0C0622B2A3CA0B426E1FE5D1 /* Pods-SelfConference.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelfConference.appstore.xcconfig"; path = "Target Support Files/Pods-SelfConference/Pods-SelfConference.appstore.xcconfig"; sourceTree = "<group>"; };
 		1F0734E91B0C1B7B00A74989 /* SCSpeakerCollectionViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCSpeakerCollectionViewCell.h; sourceTree = "<group>"; };
 		1F0734EA1B0C1B7B00A74989 /* SCSpeakerCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCSpeakerCollectionViewCell.m; sourceTree = "<group>"; };
 		1F0734EC1B0C203900A74989 /* UIAlertController+SCAlertController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertController+SCAlertController.h"; sourceTree = "<group>"; };
@@ -178,14 +179,11 @@
 		1FE566731B0D7A6B00044DFE /* SCNameLabelHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCNameLabelHeaderView.m; sourceTree = "<group>"; };
 		1FE566751B0D812000044DFE /* SCCodeOfConductViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SCCodeOfConductViewController.h; sourceTree = "<group>"; };
 		1FE566761B0D812000044DFE /* SCCodeOfConductViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCCodeOfConductViewController.m; sourceTree = "<group>"; };
-		2D10993C3C99F6944FEAF14F /* Pods-SelfConferenceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelfConferenceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SelfConferenceTests/Pods-SelfConferenceTests.debug.xcconfig"; sourceTree = "<group>"; };
-		37D95520F9868BAA20A1EBC8 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
-		3B1457BA96527132726AC017 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		5EE50E0DDACDE2B2A8D764A2 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		60EF66F9348AD1F837863DB2 /* Pods.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.appstore.xcconfig; path = "Pods/Target Support Files/Pods/Pods.appstore.xcconfig"; sourceTree = "<group>"; };
-		712342F2F08C3B3194CF395D /* Pods-SelfConferenceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelfConferenceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SelfConferenceTests/Pods-SelfConferenceTests.release.xcconfig"; sourceTree = "<group>"; };
-		BD8F553853A58875DD1A6969 /* libPods-SelfConferenceTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SelfConferenceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D94D5F52919A1DAD2791CEEF /* Pods-SelfConferenceTests.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelfConferenceTests.appstore.xcconfig"; path = "Pods/Target Support Files/Pods-SelfConferenceTests/Pods-SelfConferenceTests.appstore.xcconfig"; sourceTree = "<group>"; };
+		4BA4EAE78649D1E700745240 /* libPods-SelfConference.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SelfConference.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A5DC276C319587DB3AE3F5F /* Pods-SelfConference.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelfConference.debug.xcconfig"; path = "Target Support Files/Pods-SelfConference/Pods-SelfConference.debug.xcconfig"; sourceTree = "<group>"; };
+		8CC12258CF4E74435625EA2F /* Pods-SelfConferenceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelfConferenceTests.debug.xcconfig"; path = "Target Support Files/Pods-SelfConferenceTests/Pods-SelfConferenceTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C0A7A69665F9D4DB5CF1A9EB /* Pods-SelfConferenceTests.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SelfConferenceTests.appstore.xcconfig"; path = "Target Support Files/Pods-SelfConferenceTests/Pods-SelfConferenceTests.appstore.xcconfig"; sourceTree = "<group>"; };
+		D3D44B76A75D0987CA105EFC /* libPods-SelfConferenceTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SelfConferenceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,7 +191,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52177A65E8B8CFE8659C76EF /* libPods.a in Frameworks */,
+				1099BA1573579EE9343BCCA9 /* libPods-SelfConference.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -201,7 +199,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FEEAC01EB9E2FC1CB6FE80F7 /* libPods-SelfConferenceTests.a in Frameworks */,
+				7DBD12AE835AEF03A63F5646 /* libPods-SelfConferenceTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,8 +334,8 @@
 				1F7392B41A9985BE00F4B10F /* SelfConference */,
 				1F7392D11A9985BE00F4B10F /* SelfConferenceTests */,
 				1F7392B31A9985BE00F4B10F /* Products */,
-				7A498C1927ACE97829FE04A0 /* Pods */,
-				F4FCA3B9FB63EE20805148E9 /* Frameworks */,
+				F99E8E56A421B33271A76F7D /* Pods */,
+				B78B5C28EADD8B5FF8FCF609 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -430,26 +428,25 @@
 			path = API;
 			sourceTree = "<group>";
 		};
-		7A498C1927ACE97829FE04A0 /* Pods */ = {
+		B78B5C28EADD8B5FF8FCF609 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				2D10993C3C99F6944FEAF14F /* Pods-SelfConferenceTests.debug.xcconfig */,
-				712342F2F08C3B3194CF395D /* Pods-SelfConferenceTests.release.xcconfig */,
-				37D95520F9868BAA20A1EBC8 /* Pods.debug.xcconfig */,
-				5EE50E0DDACDE2B2A8D764A2 /* Pods.release.xcconfig */,
-				60EF66F9348AD1F837863DB2 /* Pods.appstore.xcconfig */,
-				D94D5F52919A1DAD2791CEEF /* Pods-SelfConferenceTests.appstore.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		F4FCA3B9FB63EE20805148E9 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BD8F553853A58875DD1A6969 /* libPods-SelfConferenceTests.a */,
-				3B1457BA96527132726AC017 /* libPods.a */,
+				4BA4EAE78649D1E700745240 /* libPods-SelfConference.a */,
+				D3D44B76A75D0987CA105EFC /* libPods-SelfConferenceTests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F99E8E56A421B33271A76F7D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8A5DC276C319587DB3AE3F5F /* Pods-SelfConference.debug.xcconfig */,
+				0C0622B2A3CA0B426E1FE5D1 /* Pods-SelfConference.appstore.xcconfig */,
+				8CC12258CF4E74435625EA2F /* Pods-SelfConferenceTests.debug.xcconfig */,
+				C0A7A69665F9D4DB5CF1A9EB /* Pods-SelfConferenceTests.appstore.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -459,12 +456,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1F7392D81A9985BE00F4B10F /* Build configuration list for PBXNativeTarget "SelfConference" */;
 			buildPhases = (
-				7604A4A8C73A27EB3FF842AC /* Check Pods Manifest.lock */,
+				B007EAA7616B992684A6BF01 /* [CP] Check Pods Manifest.lock */,
 				1F7392AE1A9985BD00F4B10F /* Sources */,
 				1F7392AF1A9985BD00F4B10F /* Frameworks */,
 				1F7392B01A9985BD00F4B10F /* Resources */,
-				8D7753CCB70737433A47F5FE /* Copy Pods Resources */,
-				A1FCF0B0E5B4D95DD73FBD26 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -479,12 +474,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1F7392DB1A9985BE00F4B10F /* Build configuration list for PBXNativeTarget "SelfConferenceTests" */;
 			buildPhases = (
-				67BC063E691D1FD53EA45890 /* Check Pods Manifest.lock */,
+				AFC97F9FFD0BF1618648A7D5 /* [CP] Check Pods Manifest.lock */,
 				1F7392CA1A9985BE00F4B10F /* Sources */,
 				1F7392CB1A9985BE00F4B10F /* Frameworks */,
 				1F7392CC1A9985BE00F4B10F /* Resources */,
-				87D9102E757C83B18A98E3DE /* Copy Pods Resources */,
-				76EFE26ACCB079DA92CFEC5C /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -555,94 +548,48 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		67BC063E691D1FD53EA45890 /* Check Pods Manifest.lock */ = {
+		AFC97F9FFD0BF1618648A7D5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
+			inputFileListPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SelfConferenceTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7604A4A8C73A27EB3FF842AC /* Check Pods Manifest.lock */ = {
+		B007EAA7616B992684A6BF01 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
+			inputFileListPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SelfConference-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		76EFE26ACCB079DA92CFEC5C /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SelfConferenceTests/Pods-SelfConferenceTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		87D9102E757C83B18A98E3DE /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SelfConferenceTests/Pods-SelfConferenceTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8D7753CCB70737433A47F5FE /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A1FCF0B0E5B4D95DD73FBD26 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -803,7 +750,7 @@
 		};
 		1F7392D91A9985BE00F4B10F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 37D95520F9868BAA20A1EBC8 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 8A5DC276C319587DB3AE3F5F /* Pods-SelfConference.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -820,7 +767,7 @@
 		};
 		1F7392DA1A9985BE00F4B10F /* AppStore */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 60EF66F9348AD1F837863DB2 /* Pods.appstore.xcconfig */;
+			baseConfigurationReference = 0C0622B2A3CA0B426E1FE5D1 /* Pods-SelfConference.appstore.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Amber Conville (6477MFL6C9)";
@@ -835,7 +782,7 @@
 		};
 		1F7392DC1A9985BE00F4B10F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2D10993C3C99F6944FEAF14F /* Pods-SelfConferenceTests.debug.xcconfig */;
+			baseConfigurationReference = 8CC12258CF4E74435625EA2F /* Pods-SelfConferenceTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -855,7 +802,7 @@
 		};
 		1F7392DD1A9985BE00F4B10F /* AppStore */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D94D5F52919A1DAD2791CEEF /* Pods-SelfConferenceTests.appstore.xcconfig */;
+			baseConfigurationReference = C0A7A69665F9D4DB5CF1A9EB /* Pods-SelfConferenceTests.appstore.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/SelfConference.xcodeproj/project.pbxproj
+++ b/SelfConference.xcodeproj/project.pbxproj
@@ -445,7 +445,6 @@
 				8CC12258CF4E74435625EA2F /* Pods-SelfConferenceTests.debug.xcconfig */,
 				C0A7A69665F9D4DB5CF1A9EB /* Pods-SelfConferenceTests.appstore.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -513,6 +512,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -756,7 +756,17 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/SelfConference/Supporting-Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/AFNetworking\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/IHKeyboardAvoiding\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MBProgressHUD\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MTCardLayout\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MTDates\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MagicalRecord\"",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SC_BUNDLE_IDENTIFIER_SUFFIX = "-debug";
@@ -772,7 +782,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Amber Conville (6477MFL6C9)";
 				INFOPLIST_FILE = "$(SRCROOT)/SelfConference/Supporting-Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/AFNetworking\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/IHKeyboardAvoiding\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MBProgressHUD\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MTCardLayout\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MTDates\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/MagicalRecord\"",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "98a2f7c6-ce02-45d4-bb8a-b2e479159d06";
 				SC_BUNDLE_NAME = self.conf;

--- a/SelfConference/Controllers/SCSessionFeedbackViewController.m
+++ b/SelfConference/Controllers/SCSessionFeedbackViewController.m
@@ -11,7 +11,7 @@
 #import "SCSession.h"
 #import "UIView+MBProgressHUD.h"
 #import "UIAlertController+SCAlertController.h"
-#import <IHKeyboardAvoiding/IHKeyboardAvoiding.h>
+@import IHKeyboardAvoiding;
 
 @interface SCSessionFeedbackViewController () <UITextViewDelegate>
 
@@ -40,7 +40,7 @@
     // of comment to go along with the vote.
     [self enableSubmitButton:NO];
     
-    [IHKeyboardAvoiding setAvoidingView:self.textView];
+    [KeyboardAvoiding setAvoidingView:self.textView];
 }
 
 - (NSString *)placeholderText {


### PR DESCRIPTION
## What does this PR do :question:
This PR contains changes that updates `Podfile` syntax, updates the Pods themselves, updates a pod reference to its Swift version, and includes changes some build settings to the project target to enable the pod that was rewritten in Swift to be used in the project. Now, the project should be able to build and run in XCode 10.2 🎉

Build setting changes:
- Runpath Search Paths: added `/usr/lib/swift` as the first argument
- Library Search Paths: added `$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)`


## How to test it :microscope:
1. Run the app!
2. The app should build and run successfully with no pod-related errors (there may be some warnings, though!)


## Any background info you would like to include :white_check_mark:
👋Hello! I'm Britney Smith, an iOS developer at Detroit Labs. @AishaBlake approached me and some of my colleagues and asked for some assistance in updating this app. I hope this contribution helps to move things along 😄 


## Screenshots (if applicable) :camera:
![selfconf-pr-project-update](https://user-images.githubusercontent.com/8409475/57808393-423e6900-7731-11e9-8ea1-fe5f19c55e6b.gif)
