### PR TITLE
Fix for feedback submissions: Change service url from 'http' to 'https'

### DIFF
--- a/SelfConference/API/SCAPIStrings.m
+++ b/SelfConference/API/SCAPIStrings.m
@@ -8,7 +8,7 @@
 
 #import "SCAPIStrings.h"
 
-NSString * const kSCAPIServiceBaseUrlString = @"http://selfconference.org/api";
+NSString * const kSCAPIServiceBaseUrlString = @"https://selfconference.org/api";
 
 const struct SCAPIRelativeUrlStrings SCAPIRelativeUrlStrings = {
     .events = @"events",

--- a/SelfConference/Supporting-Files/Info.plist
+++ b/SelfConference/Supporting-Files/Info.plist
@@ -24,8 +24,17 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>https://selfconference.org/api</key>
+			<dict/>
+            <key>NSExceptionRequiresForwardSecrecy</key>
+            <true/>
+            <key>NSRequiresCertificateTransparency</key>
+            <true/>
+		</dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
## What does this PR do :question:
This PR changes the `kSCAPIServiceBaseUrlString` from `http://...` to `https://`. This fixes a bug in which feedback submission POST requests got a `307 Temporary Redirect` response from the server, but the request didn't seem to be successfully redirected and accepted. 

The ATS rules were also updated to fit modern standards of the App Store.

## How to test it :microscope:
A simple way to test this fix is to use [Charles](https://www.charlesproxy.com/documentation/welcome/) to record the web traffic from the Simulator while submitting a feedback submission in the `Self.conference Debug` scheme of the app (see screenshots below)

Here's the resource I used to set up Charles for the iOS Simulator: https://www.detroitlabs.com/blog/2018/05/01/how-to-set-up-charles-proxy-for-an-ios-simulator/

## Any background info you would like to include :white_check_mark:
N/A

## Screenshots (if applicable) :camera:
![Screen Shot 2019-05-23 at 11 20 48 AM](https://user-images.githubusercontent.com/8409475/58281903-45a9a400-7d72-11e9-9ead-c8b3b4995f32.png)
![Simulator Screen Shot - iPhone X - 2019-05-23 at 15 37 36](https://user-images.githubusercontent.com/8409475/58282145-e39d6e80-7d72-11e9-86b4-4baae42f63d7.png)
![Simulator Screen Shot - iPhone X - 2019-05-23 at 15 37 53](https://user-images.githubusercontent.com/8409475/58282165-f0ba5d80-7d72-11e9-87b7-a3d15fe63ac2.png)
<img width="894" alt="Screen Shot 2019-05-23 at 10 49 09 AM" src="https://user-images.githubusercontent.com/8409475/58281941-5a863780-7d72-11e9-94a0-e89d6f1d908b.png">
